### PR TITLE
:sparkles: Creates Initial Deployment Module

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @deseretdigital/platform-engineering

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# terraform-ddm-platform-deployment
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.81 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.23 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_deployment.platform_deployment](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_horizontal_pod_autoscaler_v2.deployment_hpa](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/horizontal_pod_autoscaler_v2) | resource |
+| [kubernetes_secret.kubernetes_secrets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_service.web_servce](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
+| [kubernetes_namespace.deployment_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/namespace) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_application_name"></a> [application\_name](#input\_application\_name) | The name of the deployment | `string` | n/a | yes |
+| <a name="input_application_version"></a> [application\_version](#input\_application\_version) | The version of the deployment. Ideally this is an Autotagged Semver, but we could use the Github run id. | `string` | n/a | yes |
+| <a name="input_autoscaler"></a> [autoscaler](#input\_autoscaler) | Configuration for the autoscaler | <pre>object({<br>    cpu_utilization    = optional(number)<br>    memory_utilization = optional(number)<br>    # External Metrics. Example: Google Pubsub<br>    external_metric = optional(object({<br>      metric_name     = string<br>      target_value    = string<br>      selector_labels = optional(map(string))<br>    }))<br>  })</pre> | <pre>{<br>  "cpu_utilization": 80<br>}</pre> | no |
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | The container image to deploy | `string` | n/a | yes |
+| <a name="input_container_port"></a> [container\_port](#input\_container\_port) | The port the container exposes | `number` | `8080` | no |
+| <a name="input_deployment_service_type"></a> [deployment\_service\_type](#input\_deployment\_service\_type) | The type of service to create for the deployment | `string` | `"ClusterIP"` | no |
+| <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | List of environment variables for the deployment | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_expose_as_web_service"></a> [expose\_as\_web\_service](#input\_expose\_as\_web\_service) | Indicates if the deployment should be exposed as a web service | `bool` | `true` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | The labels to apply to the deployment | `map(string)` | n/a | yes |
+| <a name="input_liveness_probe"></a> [liveness\_probe](#input\_liveness\_probe) | Configuration for liveness probe | <pre>object({<br>    path                  = optional(string)<br>    port                  = optional(number)<br>    initial_delay_seconds = optional(number)<br>    period_seconds        = optional(number)<br>    timeout_seconds       = optional(number)<br>    failure_threshold     = optional(number)<br>    success_threshold     = optional(number)<br>  })</pre> | <pre>{<br>  "failure_threshold": 3,<br>  "initial_delay_seconds": 10,<br>  "path": "/livez",<br>  "period_seconds": 10,<br>  "port": 8080,<br>  "success_threshold": 1,<br>  "timeout_seconds": 2<br>}</pre> | no |
+| <a name="input_max_replicas"></a> [max\_replicas](#input\_max\_replicas) | Maximum number of replicas for the deployment | `number` | `1` | no |
+| <a name="input_min_replicas"></a> [min\_replicas](#input\_min\_replicas) | Minimum number of replicas for the deployment | `number` | `1` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where the deployment will be created | `string` | `"internal"` | no |
+| <a name="input_readiness_probe"></a> [readiness\_probe](#input\_readiness\_probe) | Configuration for readiness probe | <pre>object({<br>    path                  = optional(string)<br>    port                  = optional(number)<br>    initial_delay_seconds = optional(number)<br>    period_seconds        = optional(number)<br>    timeout_seconds       = optional(number)<br>    failure_threshold     = optional(number)<br>    success_threshold     = optional(number)<br>  })</pre> | <pre>{<br>  "failure_threshold": 3,<br>  "initial_delay_seconds": 10,<br>  "path": "/readyz",<br>  "period_seconds": 10,<br>  "port": 8080,<br>  "success_threshold": 1,<br>  "timeout_seconds": 2<br>}</pre> | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | Resource requests and limits | <pre>object({<br>    requests = object({<br>      cpu    = string<br>      memory = string<br>    })<br>    limits = object({<br>      cpu    = string<br>      memory = string<br>    })<br>  })</pre> | <pre>{<br>  "limits": {<br>    "cpu": "500m",<br>    "memory": "128Mi"<br>  },<br>  "requests": {<br>    "cpu": "250m",<br>    "memory": "64Mi"<br>  }<br>}</pre> | no |
+| <a name="input_secret_env_vars"></a> [secret\_env\_vars](#input\_secret\_env\_vars) | List of environment that are set as secret variables for the deployment. These are stored in K8s and not in GSM | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_team"></a> [team](#input\_team) | The team that owns the deployment | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_name"></a> [name](#output\_name) | The name of the deployment |

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,5 @@
+data "kubernetes_namespace" "deployment_namespace" {
+  metadata {
+    name = var.namespace
+  }
+}

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -1,0 +1,151 @@
+locals {
+  # Set the default values for the health check
+  # We set the defaults as a local so that we can merge them with the user 
+  # provided values. This allows uses to only overide the some values on 
+  # the resource object. It also allows us to use the container_port, to avoid
+  # setting redundant values in our code.
+  liveness_probe_defaults = {
+    path                  = "/livez"
+    port                  = var.container_port
+    initial_delay_seconds = 10
+    period_seconds        = 10
+    timeout_seconds       = 2
+    failure_threshold     = 3
+    success_threshold     = 1
+  }
+  # Merge Local values with user provided values
+  liveness_probe = merge(local.liveness_probe_defaults, var.liveness_probe)
+
+  readiness_probe_defaults = {
+    path                  = "/livez"
+    port                  = var.container_port
+    initial_delay_seconds = 10
+    period_seconds        = 10
+    timeout_seconds       = 2
+    failure_threshold     = 3
+    success_threshold     = 1
+  }
+  # Merge Local values with user provided values
+  readiness_probe = merge(local.readiness_probe_defaults, var.readiness_probe)
+}
+
+
+resource "kubernetes_deployment" "platform_deployment" {
+  metadata {
+    name      = "${var.application_name}-deployment"
+    namespace = data.kubernetes_namespace.deployment_namespace.id
+
+    labels = var.labels
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = var.application_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = local.labels
+      }
+
+      spec {
+        container {
+          name  = var.application_name
+          image = var.container_image
+
+          ########################################## 
+          # Dynamic environment variables
+          ##########################################
+          dynamic "env" {
+            for_each = var.env_vars
+            content {
+              name  = env.value.name
+              value = env.value.value
+            }
+          }
+
+          ##########################################
+          # Static environment variables
+          ##########################################
+
+          # Set the DD_AGENT_HOST environment variable to the host IP address.
+          env {
+            name = "DD_AGENT_HOST"
+
+            value_from {
+              field_ref {
+                field_path = "status.hostIP"
+              }
+            }
+          }
+
+          env {
+            name  = "DD_SERVICE"
+            value = "ddm-platform-${var.application_name}"
+          }
+
+          env {
+            name  = "DD_VERSION"
+            value = var.application_version
+          }
+
+          port {
+            container_port = var.container_port
+            protocol       = "TCP"
+          }
+
+          # Resource limits and requests for the container. This is used by
+          # Kubernetes to schedule the container on a node. It is also used by
+          # the Horizontal Pod Autoscaler to determine when to scale the workload.
+          resources {
+            limits = {
+              cpu    = var.resources.limits.cpu
+              memory = var.resources.limits.memory
+            }
+
+            requests = {
+              cpu    = var.resources.requests.cpu
+              memory = var.resources.requests.memory
+            }
+          }
+
+
+          # Health Checks probes for the container. Currently limited to http 
+          # health checks only and expects the port to be the same as the 
+          # container port. This is intentional to simplify the configuration.
+          liveness_probe {
+            http_get {
+              path = local.liveness_probe.path
+              port = local.liveness_probe.port
+            }
+
+            initial_delay_seconds = local.liveness_probe.initial_delay_seconds
+            period_seconds        = local.liveness_probe.period_seconds
+            timeout_seconds       = local.liveness_probe.timeout_seconds
+            failure_threshold     = local.liveness_probe.failure_threshold
+            success_threshold     = local.liveness_probe.success_threshold
+          }
+
+          readiness_probe {
+            http_get {
+              path = local.readiness_probe.path
+              port = local.readiness_probe.port
+            }
+
+            initial_delay_seconds = local.readiness_probe.initial_delay_seconds
+            period_seconds        = local.readiness_probe.period_seconds
+            timeout_seconds       = local.readiness_probe.timeout_seconds
+            failure_threshold     = local.readiness_probe.failure_threshold
+            success_threshold     = local.readiness_probe.success_threshold
+          }
+        }
+      }
+    }
+
+    min_ready_seconds = 60
+  }
+}

--- a/kubernetes_horizontal_scaling.tf
+++ b/kubernetes_horizontal_scaling.tf
@@ -1,0 +1,72 @@
+resource "kubernetes_horizontal_pod_autoscaler_v2" "deployment_hpa" {
+  # Only createa an autoscaler if the max_replicas is greater than the min_replicas.
+  count = var.max_replicas > var.min_replicas ? 1 : 0
+
+  metadata {
+    name      = "${var.application_name}-autoscaler"
+    namespace = data.kubernetes_namespace.deployment_namespace.id
+    labels    = local.labels
+  }
+
+  spec {
+    scale_target_ref {
+      api_version = "apps/v1"
+      kind        = "Deployment"
+      name        = kubernetes_deployment.platform_deployment.metadata[0].name
+    }
+
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    dynamic "metric" {
+      for_each = var.autoscaler.cpu_utilization != null ? [var.autoscaler.cpu_utilization] : []
+      content {
+        type = "Resource"
+        resource {
+          name = "cpu"
+          target {
+            type                = "Utilization"
+            average_utilization = metric.value
+          }
+        }
+      }
+    }
+
+    dynamic "metric" {
+      for_each = var.autoscaler.memory_utilization != null ? [var.autoscaler.memory_utilization] : []
+      content {
+        type = "Resource"
+        resource {
+          name = "memory"
+          target {
+            type                = "Utilization"
+            average_utilization = metric.value
+          }
+        }
+      }
+    }
+
+    # External Metric (Most common use is Google Pubsub in this case)
+    # An Example metric name is: pubsub.googleapis.com|{SUBSCRIPTION_NAME}|num_undelivered_messages
+    dynamic "metric" {
+      for_each = var.autoscaler.external_metric != null ? [var.autoscaler.external_metric] : []
+      content {
+        type = "External"
+        external {
+          metric {
+            name = metric.value.metric_name
+            selector {
+              match_labels = {
+                for k, v in metric.value.selector_labels : k => v
+              }
+            }
+          }
+          target {
+            type          = "AverageValue"
+            average_value = metric.value.target_value
+          }
+        }
+      }
+    }
+  }
+}

--- a/kubernetes_secrets.tf
+++ b/kubernetes_secrets.tf
@@ -1,0 +1,28 @@
+# # Kuberenets Secrets
+# 
+# Each secret is a key/value pair used by the application to access secrets.
+# The secrets are sourced from GitHub secrets and stored in Kubernetes secrets.
+# To update a secret's value, visit the GitHub repository and navigate to: 
+# Settings > Secrets and variables > Actions.
+#
+# Example: For APP_SECRET, the key would be "APP_SECRET", and the value would be 
+# the secret within GitHub Actions.
+#
+# Note: We don't want to use these types of secrets in most cases. This exists 
+# to handle legacy applications that are not yet ready to use Google Secret Manager.
+
+locals {
+  secrets_map = { for secret in var.secret_env_vars : secret.name => secret.value }
+}
+
+resource "kubernetes_secret" "kubernetes_secrets" {
+  # Create Secrets block only when we have secrets
+  count = length(var.secret_env_vars) > 0 ? 1 : 0
+
+  metadata {
+    name      = "${var.application_name}-secrets"
+    namespace = data.kubernetes_namespace.deployment_namespace.id
+  }
+
+  data = local.secrets_map
+}

--- a/kubernetes_service.tf
+++ b/kubernetes_service.tf
@@ -1,0 +1,30 @@
+
+resource "kubernetes_service" "web_servce" {
+  # Only expose the service as a web service if the variable is set to true.
+  count = var.expose_as_web_service ? 1 : 0
+
+  metadata {
+    name      = "${var.application_name}-svc"
+    namespace = data.kubernetes_namespace.deployment_namespace.id
+    annotations = {
+      "cloud.google.com/neg" = "{\"ingress\": true}"
+    }
+    labels = local.labels
+  }
+
+  spec {
+    port {
+      name     = "${var.application_name}-port"
+      protocol = "TCP"
+      # Assume all containers expose port 80 to the ingress for now.
+      port        = 80
+      target_port = var.container_port
+    }
+
+    selector = {
+      app = var.application_name
+    }
+
+    type = var.deployment_service_type
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.81"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+# Merge labels from the user with the labels we need to apply to the deployment
+locals {
+  labels = merge(
+    {
+      app  = var.application_name
+      team = var.team
+    },
+    var.labels
+  )
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The name of the deployment"
+  value       = kubernetes_deployment.platform_deployment.metadata[0].name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,168 @@
+variable "application_name" {
+  description = "The name of the deployment"
+  type        = string
+}
+
+variable "expose_as_web_service" {
+  description = "Indicates if the deployment should be exposed as a web service"
+  type        = bool
+  default     = true
+}
+
+variable "application_version" {
+  description = "The version of the deployment. Ideally this is an Autotagged Semver, but we could use the Github run id."
+  type        = string
+}
+
+variable "container_image" {
+  description = "The container image to deploy"
+  type        = string
+}
+
+variable "container_port" {
+  description = "The port the container exposes"
+  type        = number
+  default     = 8080
+}
+
+variable "team" {
+  description = "The team that owns the deployment"
+  type        = string
+}
+
+variable "labels" {
+  description = "The labels to apply to the deployment"
+  type        = map(string)
+}
+
+variable "namespace" {
+  description = "The Kubernetes namespace where the deployment will be created"
+  type        = string
+  default     = "internal"
+}
+
+
+variable "liveness_probe" {
+  description = "Configuration for liveness probe"
+  type = object({
+    path                  = optional(string)
+    port                  = optional(number)
+    initial_delay_seconds = optional(number)
+    period_seconds        = optional(number)
+    timeout_seconds       = optional(number)
+    failure_threshold     = optional(number)
+    success_threshold     = optional(number)
+  })
+  default = {
+    path                  = "/livez"
+    port                  = 8080 # Added this default
+    initial_delay_seconds = 10
+    period_seconds        = 10
+    timeout_seconds       = 2
+    failure_threshold     = 3
+    success_threshold     = 1
+  }
+}
+
+variable "readiness_probe" {
+  description = "Configuration for readiness probe"
+  type = object({
+    path                  = optional(string)
+    port                  = optional(number)
+    initial_delay_seconds = optional(number)
+    period_seconds        = optional(number)
+    timeout_seconds       = optional(number)
+    failure_threshold     = optional(number)
+    success_threshold     = optional(number)
+  })
+  default = {
+    path                  = "/readyz"
+    port                  = 8080 # Added this default
+    initial_delay_seconds = 10
+    period_seconds        = 10
+    timeout_seconds       = 2
+    failure_threshold     = 3
+    success_threshold     = 1
+  }
+}
+
+
+
+variable "resources" {
+  description = "Resource requests and limits"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      memory = "64Mi"
+      cpu    = "250m"
+    }
+    limits = {
+      memory = "128Mi"
+      cpu    = "500m"
+    }
+  }
+}
+
+
+variable "env_vars" {
+  description = "List of environment variables for the deployment"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "secret_env_vars" {
+  description = "List of environment that are set as secret variables for the deployment. These are stored in K8s and not in GSM"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default   = []
+  sensitive = true
+}
+
+variable "min_replicas" {
+  description = "Minimum number of replicas for the deployment"
+  type        = number
+  default     = 1
+}
+
+variable "max_replicas" {
+  description = "Maximum number of replicas for the deployment"
+  type        = number
+  default     = 1
+}
+
+variable "autoscaler" {
+  description = "Configuration for the autoscaler"
+  type = object({
+    cpu_utilization    = optional(number)
+    memory_utilization = optional(number)
+    # External Metrics. Example: Google Pubsub
+    external_metric = optional(object({
+      metric_name     = string
+      target_value    = string
+      selector_labels = optional(map(string))
+    }))
+  })
+  default = {
+    cpu_utilization = 80 # This implies 80%
+  }
+}
+
+variable "deployment_service_type" {
+  description = "The type of service to create for the deployment"
+  type        = string
+  default     = "ClusterIP"
+}


### PR DESCRIPTION
Introduce new module for streamlined K8s terraform deployment:

- Simplify boilerplate terraform for K8s deployment.
- Apply labels across all generated resources.
- Conditionally create a service for web-exposed apps.
- Add K8s secrets only when specified.
- Implement HPA when max_replicas > 1:
  - Default scaling on CPU.
  - Options for memory scaling and custom metrics via Google Metrics Service.