### PR TITLE
Add Secrets env variables

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -69,6 +69,22 @@ resource "kubernetes_deployment" "platform_deployment" {
             }
           }
 
+          ########################################## 
+          # Dynamic secret environment variables
+          ##########################################
+          dynamic "env" {
+            for_each = var.secret_env_vars
+            content {
+              name = env.value.name
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret.kubernetes_secrets.metadata[0].name
+                  key  = env.value.name
+                }
+              }
+            }
+          }
+
           ##########################################
           # Static environment variables
           ##########################################


### PR DESCRIPTION
We need to use k8s secrets in some cases. For example, when we have a legacy service that takes its secrets from ENV values this adds a block to loop over the secrets given and set them as env values on the container.