### PR TITLE
feat(gcp): export service account as module output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "name" {
   description = "The name of the deployment"
   value       = kubernetes_deployment.platform_deployment.metadata[0].name
 }
+
+output "service_account" {
+  description = "The name of the service account"
+  value       = module.deployment_workload_identity.gcp_service_account
+}


### PR DESCRIPTION
Exported the GCP service account created within the module as an output. This enables additional permissions to be added to the service account more easily.