### PR TITLE
refactor(terraform): accept secrets as map, remove sensitive flag

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -64,8 +64,8 @@ resource "kubernetes_deployment" "platform_deployment" {
           dynamic "env" {
             for_each = var.env_vars
             content {
-              name  = env.value.name
-              value = env.value.value
+              name  = env.key
+              value = env.value
             }
           }
 
@@ -75,11 +75,11 @@ resource "kubernetes_deployment" "platform_deployment" {
           dynamic "env" {
             for_each = var.secret_env_vars
             content {
-              name = env.value.name
+              name = env.key
               value_from {
                 secret_key_ref {
-                  name = kubernetes_secret.kubernetes_secrets.metadata[0].name
-                  key  = env.value.name
+                  name = kubernetes_secret.kubernetes_secrets[0].metadata[0].name
+                  key  = env.key
                 }
               }
             }

--- a/kubernetes_secrets.tf
+++ b/kubernetes_secrets.tf
@@ -9,12 +9,10 @@
 # the secret within GitHub Actions.
 #
 # Note: We don't want to use these types of secrets in most cases. This exists 
-# to handle legacy applications that are not yet ready to use Google Secret Manager.
+# to handle legacy applications that are not yet ready to use Google Secret Manager
 
-locals {
-  secrets_map = { for secret in var.secret_env_vars : secret.name => secret.value }
-}
-
+// We need to always create a secret, even if there are no secret env vars
+// This is so we
 resource "kubernetes_secret" "kubernetes_secrets" {
   # Create Secrets block only when we have secrets
   count = length(var.secret_env_vars) > 0 ? 1 : 0
@@ -24,5 +22,5 @@ resource "kubernetes_secret" "kubernetes_secrets" {
     namespace = data.kubernetes_namespace.deployment_namespace.id
   }
 
-  data = local.secrets_map
+  data = var.secret_env_vars
 }

--- a/variables.tf
+++ b/variables.tf
@@ -115,21 +115,14 @@ variable "resources" {
 
 variable "env_vars" {
   description = "List of environment variables for the deployment"
-  type = list(object({
-    name  = string
-    value = string
-  }))
-  default = []
+  type        = map(any)
+  default     = {}
 }
 
 variable "secret_env_vars" {
   description = "List of environment that are set as secret variables for the deployment. These are stored in K8s and not in GSM"
-  type = list(object({
-    name  = string
-    value = string
-  }))
-  default   = []
-  sensitive = true
+  type        = map(any)
+  default     = {}
 }
 
 variable "min_replicas" {


### PR DESCRIPTION
BREAKING CHANGE: The Terraform module now accepts secrets in the form of a map instead of a list. The  flag has also been removed from the secrets variable within the module. Users of the module are now responsible for marking their own secrets as sensitive.