### PR TITLE
Fixes health checks, and adds DD Agent Host for node js

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -17,7 +17,7 @@ locals {
   liveness_probe = merge(local.liveness_probe_defaults, var.liveness_probe)
 
   readiness_probe_defaults = {
-    path                  = "/livez"
+    path                  = "/readyz"
     port                  = var.container_port
     initial_delay_seconds = 10
     period_seconds        = 10

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -100,6 +100,18 @@ resource "kubernetes_deployment" "platform_deployment" {
             }
           }
 
+          # Nodejs uses the DD_TRACE_AGENT_HOSTNAME environment variable to set 
+          # the agent instead of DD_AGENT_HOST. We can set both without any negative effects.
+          env {
+            name = "DD_TRACE_AGENT_HOSTNAME"
+
+            value_from {
+              field_ref {
+                field_path = "status.hostIP"
+              }
+            }
+          }
+
           env {
             name  = "DD_SERVICE"
             value = "ddm-platform-${var.application_name}"


### PR DESCRIPTION
Nodejs uses a different env variable for its Datadog config than every other language. This just sets both DD_AGENT_HOST and DD_TRACE_AGENT_HOSTNAME to ensure any code in the deployments will have access to the Datadog agent