### PR TITLE
feat(k8s): add cars.ksl.com to host_aliases block

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -56,7 +56,7 @@ resource "kubernetes_deployment" "platform_deployment" {
         service_account_name = module.deployment_workload_identity.k8s_service_account_name
 
         host_aliases {
-          hostnames = ["api3.ksl.com"]
+          hostnames = ["api3.ksl.com", "cars.ksl.com"]
           ip        = "10.13.20.163"
         }
 


### PR DESCRIPTION
Added cars.ksl.com to the host_aliases block in the Kubernetes Terraform configuration to ensure proper hostname resolution.
