### PR TITLE
Updates Default Values for Replicas

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -128,13 +128,13 @@ variable "secret_env_vars" {
 variable "min_replicas" {
   description = "Minimum number of replicas for the deployment"
   type        = number
-  default     = 1
+  default     = 3
 }
 
 variable "max_replicas" {
   description = "Maximum number of replicas for the deployment"
   type        = number
-  default     = 1
+  default     = 5
 }
 
 variable "autoscaler" {


### PR DESCRIPTION
Updates the default value for the `min` and `max` replicas. We've set a standard of 3 being the minimum for web services. This makes sure that, unless otherwise specified, the values conform to that. 
