### PR TITLE
Update replicas to Match min_replicas

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -39,7 +39,7 @@ resource "kubernetes_deployment" "platform_deployment" {
   }
 
   spec {
-    replicas = 1
+    replicas = var.min_replicas
 
     selector {
       match_labels = {

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,6 @@ variable "resources" {
   }
 }
 
-
 variable "env_vars" {
   description = "List of environment variables for the deployment"
   type        = map(any)


### PR DESCRIPTION
There exists an issue if the amount of replicas requested by the deployment doesn't match the the `minimum_replicas` requested by the autoscaler. When this happens, the deployment scales to the replicas and then has to scale up. This throws un-neccesary data into the plan and is generally kind of gross. 

This change leverages the fact that we're already passing in the `min-replicas` to set both to the same number. That should prevent the plan from seeing a reason to change to a number lower than the amount requested by the HPA. 
