### PR TITLE
feat: [sc-310333] Turn on global access for internal-compute-lb

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -59,7 +59,7 @@ resource "kubernetes_deployment" "platform_deployment" {
 
         host_aliases {
           hostnames = ["api3.ksl.com", "cars.ksl.com"]
-          ip        = "10.13.20.163"
+          ip        = "10.13.20.184"
         }
 
         container {


### PR DESCRIPTION
Story details: https://app.shortcut.com/deseret/story/310333
Changed api3.ksl.com host entry to 10.13.20.184. This is the new global internal ingress.