### PR TITLE
chore: [sc-311006] Update cars-pal host_aliases to Global LB

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -31,8 +31,14 @@ variable "host_alias" {
     hostnames = list(string)
     ip        = string
   }))
-  default = {}
+  default = {
+    internal_compute_ingress = {
+      hostnames = ["api3.ksl.com", "cars.ksl.com"]
+      ip        = "10.13.20.184"
+    }
+  }
 }
+
 
 variable "labels" {
   description = "The labels to apply to the deployment"


### PR DESCRIPTION
Story details: https://app.shortcut.com/deseret/story/311006
Added hosts_aliases internal_compute_ingress entry. It points api3.ksl.com and cars.ksl.com to 10.13.20.184