### PR TITLE
Add Cron Submodule

### DIFF
--- a/modules/cronjobs/.terraform.lock.hcl
+++ b/modules/cronjobs/.terraform.lock.hcl
@@ -1,0 +1,102 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.3.4"
+  constraints = ">= 2.2.2"
+  hashes = [
+    "h1:cCabxnWQ5fX1lS7ZqgUzsvWmKZw9FA7NRxAZ94vcTcc=",
+    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
+    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
+    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
+    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
+    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
+    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
+    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
+    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
+    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
+    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.11.2"
+  constraints = ">= 3.39.0, >= 3.53.0, ~> 6.0, < 7.0.0"
+  hashes = [
+    "h1:z36TZIxzooTf7T6/mmO+TaTbzwLymk+Y70ljVapb2eM=",
+    "zh:00dc7de86e134064eebaa8a9a792de466bbbea090c0f83e5276aa421bd820740",
+    "zh:07efe84ab4557c2654e275ad0526a156aa8afbab245a1b6c0b25807d36b529ba",
+    "zh:17c029263afaf24e09078a1e65df4e12562304cc05f2f728b141e211f8959dc1",
+    "zh:381c13a92e059a8167d08ade6ed3248e61e192214ed49d401a9efb46ff707d2d",
+    "zh:761a1ba29e56245a553eef936eb4b16a10c1ec596b0eadd6c9d5951152bc27ee",
+    "zh:7956a1793ead6071c5787e25611f21f8272681ade94a47199483df03671a9b3a",
+    "zh:83fd6d976253ab911c947a79b9fa9450179605660727c0765c85b00ef054ec9b",
+    "zh:94a6566cc7db6a6f19cc6e05a30a7d4b6a8c4c668c8b9e14db17d2ee34b0678e",
+    "zh:a1a44bf143c8ebdcb7994f19897591fcce4d7480087daddaecaf0c587ba28d69",
+    "zh:d7f0e21c61638268267bd75160c01ec9f2339e357696159c9c7e2787310a0400",
+    "zh:e5b8b1f822549b0c1eb2c999e90548465774ee3bff15d284020a3d84c35f3af6",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.33.0"
+  constraints = "~> 2.0, ~> 2.13"
+  hashes = [
+    "h1:HDyytvOlqNw5fJ0SB/nzgqCWniK4LAZNx23LaPavQq8=",
+    "zh:255b35790b706d405e987750190658dcaefb663741b96803a9529ba5d7435329",
+    "zh:362feba1aa820a8e02869ec71d1a08e87243dbce43671dc0995fa6c5a2fafa1d",
+    "zh:39332abcf75b5dd9c78c79c7c0c094f7d4ca908d1b76bbd2aae67e8e3516710c",
+    "zh:3e8e7f758bb09a9b5b613c8866e77541f8f00b521070cc86bc095ce61f010baf",
+    "zh:427883b889b9c36630c3eec4d5c07bc4ae12cc0d358fc17ea42a8049bf8d5275",
+    "zh:69bfc4ed067a5e4844db1a1809343652ff239aa0a8da089b1671524c44e8740a",
+    "zh:6b9f731062b945c5020e0930ed9a1b1b50afd2caf751f0e70a282d165c970979",
+    "zh:6faf9ec006af7ee7014a9c3251d65b701792abb823f149b0b7e4ac4433848201",
+    "zh:b706f76d695104a47682ee6ab842870f9c70a680f979fa9e7efe34278c0831bc",
+    "zh:b9bca48de2c92f57389ed58dd2fac564deaccd79a92cafd08edeed3ba6b91d4d",
+    "zh:bbd3336dbee5aed9880f98e36fb8340e0c6d8f0399a05787521af599ccb3dac4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/modules/cronjobs/data.tf
+++ b/modules/cronjobs/data.tf
@@ -1,0 +1,5 @@
+data "kubernetes_namespace" "deployment_namespace" {
+  metadata {
+    name = var.namespace
+  }
+}

--- a/modules/cronjobs/kubernetes-deployment.tf
+++ b/modules/cronjobs/kubernetes-deployment.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_cron_job_v1" "cron" {
   metadata {
     name      = "${lower(var.application_name)}-cronjob"
-    namespace = var.namespace
+    namespace = data.kubernetes_namespace.deployment_namespace.id
 
     labels = var.labels
   }

--- a/modules/cronjobs/kubernetes-deployment.tf
+++ b/modules/cronjobs/kubernetes-deployment.tf
@@ -1,0 +1,100 @@
+resource "kubernetes_cron_job_v1" "cron" {
+  metadata {
+    name      = "${lower(var.application_name)}-cronjob"
+    namespace = var.namespace
+
+    labels = var.labels
+  }
+
+  spec {
+    schedule                      = var.schedule
+    concurrency_policy            = "Forbid"
+    starting_deadline_seconds     = 100
+    successful_jobs_history_limit = 5
+    failed_jobs_history_limit     = 1
+
+    job_template {
+      metadata {}
+
+      spec {
+        backoff_limit = 0
+
+        template {
+          metadata {}
+
+          spec {
+            service_account_name = module.kubernetes_workload_identity.k8s_service_account_name
+
+            restart_policy = "Never"
+
+            container {
+              name  = lower(var.application_name)
+              image = var.container_image
+
+              # Set the DD_AGENT_HOST environment variable to the host IP address.
+              dynamic "env" {
+                for_each = var.env_vars
+                content {
+                  name  = env.key
+                  value = env.value
+                }
+              }
+
+              ##########################################
+              # Static environment variables
+              ##########################################
+
+              # Set the DD_AGENT_HOST environment variable to the host IP address.
+              env {
+                name = "DD_AGENT_HOST"
+
+                value_from {
+                  field_ref {
+                    field_path = "status.hostIP"
+                  }
+                }
+              }
+
+              # Nodejs uses the DD_TRACE_AGENT_HOSTNAME environment variable to set 
+              # the agent instead of DD_AGENT_HOST. We can set both without any negative effects.
+              env {
+                name = "DD_TRACE_AGENT_HOSTNAME"
+
+                value_from {
+                  field_ref {
+                    field_path = "status.hostIP"
+                  }
+                }
+              }
+
+              env {
+                name  = "DD_SERVICE"
+                value = "ddm-platform-${var.application_name}"
+              }
+
+              env {
+                name  = "DD_VERSION"
+                value = var.application_version
+              }
+
+              # Resource limits and requests for the container. This is used by
+              # Kubernetes to schedule the container on a node. It is also used by
+              # the Horizontal Pod Autoscaler to determine when to scale the workload.
+              resources {
+                limits = {
+                  cpu    = var.resources.limits.cpu
+                  memory = var.resources.limits.memory
+                }
+
+                requests = {
+                  cpu    = var.resources.requests.cpu
+                  memory = var.resources.requests.memory
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/cronjobs/kubernetes-deployment.tf
+++ b/modules/cronjobs/kubernetes-deployment.tf
@@ -23,7 +23,7 @@ resource "kubernetes_cron_job_v1" "cron" {
           metadata {}
 
           spec {
-            service_account_name = module.kubernetes_workload_identity.k8s_service_account_name
+            service_account_name = module.deployment_workload_identity.k8s_service_account_name
 
             restart_policy = "Never"
 
@@ -51,6 +51,22 @@ resource "kubernetes_cron_job_v1" "cron" {
                 value_from {
                   field_ref {
                     field_path = "status.hostIP"
+                  }
+                }
+              }
+
+              ########################################## 
+              # Dynamic secret environment variables
+              ##########################################
+              dynamic "env" {
+                for_each = var.secret_env_vars
+                content {
+                  name = env.key
+                  value_from {
+                    secret_key_ref {
+                      name = kubernetes_secret.kubernetes_secrets[0].metadata[0].name
+                      key  = env.key
+                    }
                   }
                 }
               }

--- a/modules/cronjobs/kubernetes-secrets.tf
+++ b/modules/cronjobs/kubernetes-secrets.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_secret" "kubernetes_secrets" {
+  # Create Secrets block only when we have secrets
+  count = length(var.secret_env_vars) > 0 ? 1 : 0
+
+  metadata {
+    name      = "${var.application_name}-secrets"
+    namespace = data.kubernetes_namespace.deployment_namespace.id
+  }
+
+  data = var.secret_env_vars
+}

--- a/modules/cronjobs/kubernetes-service-account.tf
+++ b/modules/cronjobs/kubernetes-service-account.tf
@@ -1,0 +1,8 @@
+module "deployment_workload_identity" {
+  source       = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+  name         = "${var.application_name}-sa"
+  namespace    = data.kubernetes_namespace.deployment_namespace.id
+  cluster_name = var.gke_cluster_name
+  project_id   = var.project
+  roles        = var.roles
+}

--- a/modules/cronjobs/main.tf
+++ b/modules/cronjobs/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/modules/cronjobs/outputs.tf
+++ b/modules/cronjobs/outputs.tf
@@ -1,0 +1,9 @@
+output "name" {
+  description = "The name of the deployment"
+  value       = kubernetes_deployment.platform_deployment.metadata[0].name
+}
+
+output "service_account" {
+  description = "The name of the service account"
+  value       = module.deployment_workload_identity.gcp_service_account
+}

--- a/modules/cronjobs/outputs.tf
+++ b/modules/cronjobs/outputs.tf
@@ -1,8 +1,3 @@
-output "name" {
-  description = "The name of the deployment"
-  value       = kubernetes_deployment.platform_deployment.metadata[0].name
-}
-
 output "service_account" {
   description = "The name of the service account"
   value       = module.deployment_workload_identity.gcp_service_account

--- a/modules/cronjobs/variables.tf
+++ b/modules/cronjobs/variables.tf
@@ -1,0 +1,129 @@
+variable "application_name" {
+  description = "The name of the deployment"
+  type        = string
+}
+
+variable "application_version" {
+  description = "The version of the deployment. Ideally this is an Autotagged Semver, but we could use the Github run id."
+  type        = string
+}
+
+variable "container_image" {
+  description = "The container image to deploy"
+  type        = string
+}
+
+variable "labels" {
+  description = "The labels to apply to the deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "namespace" {
+  description = "The Kubernetes namespace where the deployment will be created"
+  type        = string
+  default     = "internal"
+}
+
+variable "team" {
+  description = "The team that owns the deployment"
+  type        = string
+}
+
+variable "wait_for_rollout" {
+  description = "Wait for the rollout of the deployment to complete."
+  type        = bool
+  default     = true
+}
+
+variable "resources" {
+  description = "Resource requests and limits"
+  type = object({
+    requests = object({
+      cpu    = string
+      memory = string
+    })
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+  })
+  default = {
+    requests = {
+      memory = "64Mi"
+      cpu    = "250m"
+    }
+    limits = {
+      memory = "128Mi"
+      cpu    = "500m"
+    }
+  }
+}
+
+variable "env_vars" {
+  description = "List of environment variables for the deployment"
+  type        = map(any)
+  default     = {}
+}
+
+variable "secret_env_vars" {
+  description = "List of environment that are set as secret variables for the deployment. These are stored in K8s and not in GSM"
+  type        = map(any)
+  default     = {}
+}
+
+variable "min_replicas" {
+  description = "Minimum number of replicas for the deployment"
+  type        = number
+  default     = 3
+}
+
+variable "max_replicas" {
+  description = "Maximum number of replicas for the deployment"
+  type        = number
+  default     = 5
+}
+
+variable "autoscaler" {
+  description = "Configuration for the autoscaler"
+  type = object({
+    cpu_utilization    = optional(number)
+    memory_utilization = optional(number)
+    # External Metrics. Example: Google Pubsub
+    external_metric = optional(object({
+      metric_name     = string
+      target_value    = string
+      selector_labels = optional(map(string))
+    }))
+  })
+  default = {
+    cpu_utilization = 80 # This implies 80%
+  }
+}
+
+variable "deployment_service_type" {
+  description = "The type of service to create for the deployment"
+  type        = string
+  default     = "ClusterIP"
+}
+
+variable "roles" {
+  description = "The roles to apply to the service account for the deployment"
+  type        = list(string)
+  default     = ["roles/secretmanager.secretAccessor"]
+}
+
+variable "project" {
+  description = "The default project."
+  type        = string
+}
+
+variable "gke_cluster_name" {
+  description = "The name of the GKE cluster where the resources will be deployed"
+  type        = string
+}
+
+variable "schedule" {
+  description = "The schedule for the cronjob"
+  type        = string
+}


### PR DESCRIPTION
In the case that a deployment is a cronjob instead of a webservice, we wanted to be able to have a similar structure. This is an iteration on the existing logic adjusted for use in a cronjob.
