### PR TITLE
Adds Command Parameter

### DIFF
--- a/modules/cronjobs/kubernetes-deployment.tf
+++ b/modules/cronjobs/kubernetes-deployment.tf
@@ -28,8 +28,9 @@ resource "kubernetes_cron_job_v1" "cron" {
             restart_policy = "Never"
 
             container {
-              name  = lower(var.application_name)
-              image = var.container_image
+              name    = lower(var.application_name)
+              image   = var.container_image
+              command = var.command
 
               # Set the DD_AGENT_HOST environment variable to the host IP address.
               dynamic "env" {

--- a/modules/cronjobs/variables.tf
+++ b/modules/cronjobs/variables.tf
@@ -127,3 +127,8 @@ variable "schedule" {
   description = "The schedule for the cronjob"
   type        = string
 }
+
+variable "command" {
+  description = "The command to run in the container"
+  type        = list(string)
+}


### PR DESCRIPTION
Adds the `command` parameter so the default `RUN` from the dockerimage can be over-ridden in the case that multiple cronjobs are using the same docker container. 
