### PR TITLE
Fix Command Parameter

### DIFF
--- a/modules/cronjobs/variables.tf
+++ b/modules/cronjobs/variables.tf
@@ -130,5 +130,6 @@ variable "schedule" {
 
 variable "command" {
   description = "The command to run in the container"
-  type        = list(string)
+  type        = string
+  // TODO: Figure out how to handle the case that there is no command
 }


### PR DESCRIPTION
The command parameter was set to `list(string)` instead of just `string`.
