### PR TITLE
feat: add termination_grace_period_seconds variable (3.x backport)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ module "ddm-platform-deployment" {
   max_surge           = {YOUR_MAX_PODS_SCHEDULED_DURING_UPDATE}
   max_unavailable     = {YOUR_MAX_PODS_UNAVAILABLE_DURING_UPDATED}
 
+  # Seconds to drain in-flight work on SIGTERM before SIGKILL (default 30).
+  termination_grace_period_seconds = {GRACE_PERIOD_SECONDS}
+
   
 }
 ```

--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -71,7 +71,8 @@ resource "kubernetes_deployment" "platform_deployment" {
       }
 
       spec {
-        service_account_name = module.deployment_workload_identity.k8s_service_account_name
+        service_account_name             = module.deployment_workload_identity.k8s_service_account_name
+        termination_grace_period_seconds = var.termination_grace_period_seconds
 
         host_aliases {
           hostnames = var.host_alias.hostnames

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,12 @@ variable "max_unavailable" {
   default     = "25%"
 }
 
+variable "termination_grace_period_seconds" {
+  description = "Seconds the pod is given to shut down gracefully after SIGTERM before the kubelet sends SIGKILL. Raise this for workers that need to drain long-running, in-flight work on rollout. Defaults to the Kubernetes default of 30."
+  type        = number
+  default     = 30
+}
+
 variable "autoscaler" {
   description = "Configuration for the autoscaler"
   type = object({


### PR DESCRIPTION
## Why

Workers that do long-running, in-flight work (e.g. Hank's `hank-agent` deep-agent pods) need to **drain** on rollout — finish or checkpoint the current run on SIGTERM before exiting. Today the module never sets `termination_grace_period_seconds`, so pods fall back to Kubernetes' **30s** default and get SIGKILLed mid-run during a deploy. That orphaned a Hank story (it went idle in `Implementing` right as a deploy rolled the pods).

This adds an optional `termination_grace_period_seconds` variable wired into the pod spec. **Default is 30**, so existing consumers are unaffected.

## Notes for reviewers

- **Targeted at the `3.2.7` branch, not `main`.** `main` is on the 4.x line (Google provider major migration). Hank pins `~> 3.0.0`, so this is a 3.x backport to avoid forcing the 4.x provider migration right now. The same change should also land on `main` (4.x) as a follow-up.
- **Release tagging is `main`-only** (`release-tagging.yml` runs on push to `main`), so this 3.x line needs a **manual tag** (e.g. `3.3.0`) cut after merge before consumers can pin it.
- Consumer side: `ksl-ai-hank` will set `termination_grace_period_seconds = 900` (15 min) in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)