### PR TITLE
feat: add termination_grace_period_seconds variable

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -71,7 +71,8 @@ resource "kubernetes_deployment" "platform_deployment" {
       }
 
       spec {
-        service_account_name = local.enable_workload_identity ? module.deployment_workload_identity[0].k8s_service_account_name : kubernetes_service_account.basic[0].metadata[0].name
+        service_account_name             = local.enable_workload_identity ? module.deployment_workload_identity[0].k8s_service_account_name : kubernetes_service_account.basic[0].metadata[0].name
+        termination_grace_period_seconds = var.termination_grace_period_seconds
 
         dynamic "host_aliases" {
           for_each = var.host_alias != null ? [var.host_alias] : []

--- a/variables.tf
+++ b/variables.tf
@@ -177,6 +177,12 @@ variable "max_unavailable" {
   default     = "25%"
 }
 
+variable "termination_grace_period_seconds" {
+  description = "Seconds the pod is given to shut down gracefully after SIGTERM before the kubelet sends SIGKILL. Raise this for workers that need to drain long-running, in-flight work on rollout. Defaults to the Kubernetes default of 30."
+  type        = number
+  default     = 30
+}
+
 variable "autoscaler" {
   description = "Configuration for the autoscaler"
   type = object({


### PR DESCRIPTION
## Why

Kubernetes defaults to 30s for pod termination grace period, but services with long-running in-flight work (queue consumers, batch workers) need more time to drain cleanly on rollout. Previously there was no way to configure this through the module.

## What

Adds an optional `termination_grace_period_seconds` variable (default: `30`) that maps directly to the pod spec's `terminationGracePeriodSeconds`.

```hcl
module "my-deployment" {
  # ...
  termination_grace_period_seconds = 120  # give workers 2 min to drain
}
```

Default of `30` matches the Kubernetes default — no impact on existing consumers.