### PR TITLE
fix: null-safe observability_config guards (5.x apply crash on TF 1.9)

### DIFF
--- a/kubernetes_deployment.tf
+++ b/kubernetes_deployment.tf
@@ -160,7 +160,7 @@ resource "kubernetes_deployment" "platform_deployment" {
 
           # Observability service name
           dynamic "env" {
-            for_each = var.observability_config != null && var.observability_config.service_env_var != null ? [1] : []
+            for_each = try(var.observability_config.service_env_var, null) != null ? [1] : []
             content {
               name  = var.observability_config.service_env_var
               value = var.observability_config.service_name_prefix != "" ? "${var.observability_config.service_name_prefix}${var.application_name}" : var.application_name
@@ -169,7 +169,7 @@ resource "kubernetes_deployment" "platform_deployment" {
 
           # Observability version
           dynamic "env" {
-            for_each = var.observability_config != null && var.observability_config.version_env_var != null ? [1] : []
+            for_each = try(var.observability_config.version_env_var, null) != null ? [1] : []
             content {
               name  = var.observability_config.version_env_var
               value = var.application_version

--- a/modules/cronjobs/kubernetes-deployment.tf
+++ b/modules/cronjobs/kubernetes-deployment.tf
@@ -76,7 +76,7 @@ resource "kubernetes_cron_job_v1" "cron" {
 
               # Observability service name
               dynamic "env" {
-                for_each = var.observability_config != null && var.observability_config.service_env_var != null ? [1] : []
+                for_each = try(var.observability_config.service_env_var, null) != null ? [1] : []
                 content {
                   name  = var.observability_config.service_env_var
                   value = var.observability_config.service_name_prefix != "" ? "${var.observability_config.service_name_prefix}${var.application_name}" : var.application_name
@@ -85,7 +85,7 @@ resource "kubernetes_cron_job_v1" "cron" {
 
               # Observability version
               dynamic "env" {
-                for_each = var.observability_config != null && var.observability_config.version_env_var != null ? [1] : []
+                for_each = try(var.observability_config.version_env_var, null) != null ? [1] : []
                 content {
                   name  = var.observability_config.version_env_var
                   value = var.application_version


### PR DESCRIPTION
## Why

With the default `observability_config = null`, `terraform apply` crashes during plan evaluation:

```
Error: Attempt to get attribute from null value
  on kubernetes_deployment.tf line 163 ...
  var.observability_config is null, so it does not have any attributes.
```

The observability service/version env blocks guard with:

```hcl
for_each = var.observability_config != null && var.observability_config.service_env_var != null ? [1] : []
```

Terraform does **not** reliably short-circuit `&&` when checking the right operand for errors on older CLI versions — notably **1.9**, which downstream deploy pipelines pin (this is what broke `ksl-ai-hank`'s `hank-agent` apply). So it reads `.service_env_var` off a null and hard-fails.

This is insidious because it slips through review: **`terraform validate` doesn't evaluate it, and newer CLIs (1.15) short-circuit and stay green** — so the bug only surfaces on `apply` against an older CLI.

## Fix

Replace the guards with a null-safe `try()`:

```hcl
for_each = try(var.observability_config.service_env_var, null) != null ? [1] : []
```

`try(...)` swallows the null-attribute access and yields `null` → the block is omitted, identical behavior to the intended logic, on every CLI version. Applied to both the root module (`kubernetes_deployment.tf`) and the `cronjobs` submodule, which had the same pattern.

Behavior is unchanged when `observability_config` is set. `fmt` + `validate` clean.

<details>
<summary>Note on testing</summary>

A `terraform test` plan-based regression guard does **not** reproduce this on the runners' CLI (1.15 short-circuits), so it would be a false safeguard. The durable guard is using `try()` for all optional-object attribute access (as here) and/or pinning the test CLI to the version deploy pipelines use. Happy to follow up with whichever the team prefers.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)